### PR TITLE
compatibility spfx 1.15.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ package-lock.json
 .vs/slnx.sqlite
 .vs/SpfxBaseDataServices/v16/.suo
 .vscode/*
+.idea
 
 .scannerwork/.sonar_lock
 .scannerwork/report-task.txt

--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ gulpfile.js
 tslint.json
 .vs
 .vscode
+.idea

--- a/gulp/index.js
+++ b/gulp/index.js
@@ -217,15 +217,29 @@ function mergeWebPackConfig(build, config, basePath, includeSourceMap, sourceMap
         build.verbose("Reserved names : " + reserved.join(", "));
         if (TerserPluginVersion.major >= 2) {
             TerserPlugin.isWebpack4 = () => true;
+            function escapeRegExp(string) {
+                return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+            }
+            const reservedRegex = new RegExp(`^${reserved.map(escapeRegExp).join('|')}$`);
             config.optimization.minimizer = [
                 new TerserPlugin({
                     extractComments: false,
                     parallel: false,
                     terserOptions: {
+                        ecma: 2019,
+                        keep_classnames: reservedRegex,
+                        keep_fnames: reservedRegex,
                         sourceMap: false,
-                        output: { comments: false },
-                        compress: { warnings: false },
-                        mangle: { reserved },
+                        format: { comments: false },
+                        mangle: {
+                            reserved,
+                            keep_classnames: reservedRegex,
+                            keep_fnames: reservedRegex,
+                            properties: {
+                                keep_classnames: reservedRegex,
+                                keep_fnames: reservedRegex,
+                            },
+                        },
                     },
                 }),
             ];

--- a/gulp/index.js
+++ b/gulp/index.js
@@ -226,7 +226,6 @@ function mergeWebPackConfig(build, config, basePath, includeSourceMap, sourceMap
                     extractComments: false,
                     parallel: false,
                     terserOptions: {
-                        ecma: 2019,
                         keep_classnames: reservedRegex,
                         keep_fnames: reservedRegex,
                         sourceMap: false,
@@ -235,10 +234,6 @@ function mergeWebPackConfig(build, config, basePath, includeSourceMap, sourceMap
                             reserved,
                             keep_classnames: reservedRegex,
                             keep_fnames: reservedRegex,
-                            properties: {
-                                keep_classnames: reservedRegex,
-                                keep_fnames: reservedRegex,
-                            },
                         },
                     },
                 }),

--- a/gulp/index.js
+++ b/gulp/index.js
@@ -1,10 +1,30 @@
 // dev deps in spfx package
 const TerserPlugin = require('terser-webpack-plugin');
 
-// From node 
+// From node
 const fs = require('fs');
 const glob = require('glob');
 const path = require('path');
+
+const TerserPluginVersion = (() => {
+    try {
+        const terserPath = require.resolve('terser-webpack-plugin');
+        const rootTerser = path.dirname(path.dirname(terserPath));
+        const packageJSON = path.join(rootTerser, 'package.json');
+
+        let label = '';
+        let [major='0', minor='0', fix='0'] = require(packageJSON).version.split('.');
+        [fix='0', ...label] = fix.split('-');
+        label = label?.join('-') ?? '';
+
+        [major, minor, fix] = [major, minor, fix].map(Number);
+
+        return {major, minor, fix, label};
+    } catch (error) {
+        // known version transversal used on old spfx version
+        return {major: 1, minor: 4, fix: 5, label: ''};
+    }
+})();
 
 // dev deps
 var es = require('event-stream'), PluginError = require('plugin-error');
@@ -195,26 +215,36 @@ function mergeWebPackConfig(build, config, basePath, includeSourceMap, sourceMap
 
 
         build.verbose("Reserved names : " + reserved.join(", "));
-        config.optimization.minimizer =
-            [
-                new TerserPlugin
-                    (
-                        {
-                            extractComments: false,
-                            sourceMap: false,
-                            cache: false,
-                            parallel: false,
-                            terserOptions:
-                            {
-                                output: { comments: false },
-                                compress: { warnings: false },
-                                mangle: {
-                                    reserved: reserved // rem sample from doc ['$super', '$', 'exports', 'require']
-                                }
-                            }
-                        }
-                    )
+        if (TerserPluginVersion.major >= 2) {
+            TerserPlugin.isWebpack4 = () => true;
+            config.optimization.minimizer = [
+                new TerserPlugin({
+                    extractComments: false,
+                    parallel: false,
+                    terserOptions: {
+                        sourceMap: false,
+                        output: { comments: false },
+                        compress: { warnings: false },
+                        mangle: { reserved },
+                    },
+                }),
             ];
+        }
+        else {
+            config.optimization.minimizer = [
+                new TerserPlugin({
+                    extractComments: false,
+                    sourceMap: false,
+                    cache: false,
+                    parallel: false,
+                    terserOptions: {
+                        output: { comments: false },
+                        compress: { warnings: false },
+                        mangle: { reserved }, // rem sample from doc ['$super', '$', 'exports', 'require']
+                    },
+                }),
+            ];
+        }
     }
     // alias
     config.resolve = config.resolve || { modules: ['node_modules'] };
@@ -260,7 +290,7 @@ function mergeWebPackConfig(build, config, basePath, includeSourceMap, sourceMap
     }
     if (afterMergeConfig) {
         build.log("Running addintionnal config");
-        afterSetConfig(config);
+        afterMergeConfig(config);
     }
     return config;
 }
@@ -271,7 +301,7 @@ function configureSpfxProject(build, basePath, includeSourceMap, sourceMapExclus
 
     /*
     * modify webpack config :
-    *    - to avoid uglyfying reserved names (services & models) 
+    *    - to avoid uglyfying reserved names (services & models)
     *    - to handle aliases
     *    - to link sourcmaps
     */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spfx-base-data-services",
   "description": "A set of tools to create powerfull dataservices on spfx applications",
-  "version": "1.3.36",
+  "version": "1.3.37",
   "author": {
     "name": "Matthieu LANGLOIS",
     "email": "matthieu.langlois@gmail.com"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spfx-base-data-services",
   "description": "A set of tools to create powerfull dataservices on spfx applications",
-  "version": "1.3.35",
+  "version": "1.3.36",
   "author": {
     "name": "Matthieu LANGLOIS",
     "email": "matthieu.langlois@gmail.com"


### PR DESCRIPTION
Publié sur https://github.com/theotimepoisseau-bib/spfx-base-data-services/pkgs/npm/spfx-base-data-services
testé via PV1 avec un `npm i spfx-base-data-services@npm:@theotimepoisseau-bib/spfx-base-data-services@1.3.36`
```
#.npmrc
@theotimepoisseau-bib:registry=https://npm.pkg.github.com/
```

l'api du plugin Terser à changé, et tends à avoir peu de config Terser pour la déplacer dans `terserOptions` ce qui est assez logique.
Si un payload avec un schéma incorrect est envoyé au TerserPlugin il throw une error.
J'ai estimé qu'a partir de la v2 il fallait basculer le plus de config dans `terserOptions`.

à savoir que le mangle.reserved ne semble pas parfait (je suppose qu'une phase de compression ce fait avant et casse la façon dont le mangle est capable de supporté les noms reservé) j'ai donc appliqué à `keep_classnames` et `keep_fnames` une regex qui est la concaténation des mots réservé avec l'opérateur regex OR `|`